### PR TITLE
feat(v1): Add MSBI (Misra Soil Brightness Index)

### DIFF
--- a/src/v1/indices.py
+++ b/src/v1/indices.py
@@ -3734,5 +3734,14 @@ spindex = SpectralIndices(
             date_of_addition="2026-08-19",
             contributor="https://github.com/davemlz",
         ),
+          MSBI=SpectralIndex(
+            acronym="MSBI",
+            name="Misra Soil Brightness Index",
+            formula="0.406 * G + 0.600 * R + 0.645 * N + 0.243 * N2",
+            source={"source_link": "https://doi.org/10.1080/02757259509532298"},
+            classification={"application_domain": "soil"},
+            date_of_addition="2026-09-04",
+            contributor="https://github.com/lwx4787-ops",
+        ),
     )
 )


### PR DESCRIPTION
### Summary
- Resolves #120
- Adds `MSBI` (Misra Soil Brightness Index) to the v1 `SpectralIndices` mapping in `src/v1/indices.py`.

### Index Details
- **Acronym**: MSBI
- **Name**: Misra Soil Brightness Index
- **Formula**: `0.406 * G + 0.600 * R + 0.645 * N + 0.243 * N2`
- **Domain**: soil
- **Reference**: https://doi.org/10.1080/02757259509532298 (Remote Sensing Reviews, 1995)
- **Contributor**: https://github.com/lwx4787-ops

### Validation
- Passed all v1 test suites (`test/v1/test_v1_indices.py`, `test_v1_catalogue.py`, `test_v1_formula_parser.py`, `test_v1_source.py`).
- Complies with the repository's AI and Scientific Validation Policy.